### PR TITLE
Issues in Managing Auth Token Expiration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vippsno/vipps-sdk",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vippsno/vipps-sdk",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "async-retry": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vippsno/vipps-sdk",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "homepage": "https://developer.vippsmobilepay.com/docs/SDKs/node-sdk",
   "repository": {
     "type": "git",

--- a/src/infrastructure/access-token-client.ts
+++ b/src/infrastructure/access-token-client.ts
@@ -42,11 +42,11 @@ export class AccessTokenClient {
     }
 
     const maxValidTo = new Date();
-    maxValidTo.setMinutes(maxValidTo.getMinutes() - 3);
+    maxValidTo.setMinutes(maxValidTo.getMinutes() + 3);
 
     const expiresOn = new Date(0);
     expiresOn.setSeconds(this.tokenSet.expires_on);
 
-    return maxValidTo < expiresOn;
+    return maxValidTo > expiresOn;
   }
 }

--- a/src/infrastructure/access-token-client.ts
+++ b/src/infrastructure/access-token-client.ts
@@ -44,6 +44,9 @@ export class AccessTokenClient {
     const maxValidTo = new Date();
     maxValidTo.setMinutes(maxValidTo.getMinutes() - 3);
 
-    return maxValidTo < new Date(this.tokenSet.expires_on);
+    const expiresOn = new Date(0);
+    expiresOn.setSeconds(this.tokenSet.expires_on);
+
+    return maxValidTo < expiresOn;
   }
 }


### PR DESCRIPTION
Hello,

I wanted to let you know that there seem to be some issues with managing auth token expiration, specifically with the `isExpired` method in `src/infrastructure/access-token-client.ts`.

```
private isExpired(): boolean {
    if (!this.tokenSet) {
      return true;
    }

    const maxValidTo = new Date();
    maxValidTo.setMinutes(maxValidTo.getMinutes() - 3);

    return maxValidTo < new Date(this.tokenSet.expires_on);
}
```


1. Passing a string to the Date constructor will return Invalid Date, which, when compared with another Date, always returns false.

The token itself looks like this, and expires_on is a string:
```
{
  token_type: 'Bearer',
  expires_in: '3599',
  ext_expires_in: '0',
  access_token: 'eyJ0eXA…',
  expires_on: '1701364017',
  not_before: '1701360418',
  resource: '00000003-0000-0000-c000-000000000000'
}
```
```
> new Date('1701364017')
Invalid Date

> new Date('1701364017') < new Date()
false
> new Date('1701364017') > new Date()
false
```


2. Even if we pass the timestamp as a number, the Date constructor expects it to be in milliseconds, whereas the timestamp in the token is in seconds, resulting in an incorrect Date being generated.
```
> new Date(1701364017)
1970-01-20T16:36:04.017Z
```


3. The logic in the return statement seems incorrect:
```
maxValidTo < new Date(this.tokenSet.expires_on)
```
If maxValidTo (which is the current time minus 3 minutes) is greater than the token expiration time, it means the token is already expired, but the condition will return false, which seems wrong given the method's name isExpired. Conversely, if maxValidTo is less than the expiration time, it means the token is still valid, but the condition will return true. I believe the condition should be reversed.

I’ve reproduced the error in the Node.js REPL:
```
> function isExpired(expirationTime) {
   const maxValidTo = new Date();
   maxValidTo.setMinutes(maxValidTo.getMinutes() - 3);

   return maxValidTo < expirationTime;
 }
undefined
> const past = new Date();
undefined
> past.setHours(past.getHours() - 2);
1701356483323
> const future = new Date();
undefined
> future.setHours(future.getHours() + 2);
1701370907190
> isExpired(past)
false
> isExpired(future)
true
```

All of this results in sending an expired token when trying to create a payment. Payments work perfectly for an hour (the token's lifespan) after the token is created first time. After one hour, I constantly get 401 HTTP status code.