### PR TITLE
return object instead of string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vippsno/vipps-sdk",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vippsno/vipps-sdk",
-      "version": "0.9.14",
+      "version": "0.9.15",
       "license": "MIT",
       "dependencies": {
         "@vippsno/vipps-sdk": "^0.9.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vippsno/vipps-sdk",
-  "version": "0.9.15",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vippsno/vipps-sdk",
-      "version": "0.9.15",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@vippsno/vipps-sdk": "^0.9.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vippsno/vipps-sdk",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "homepage": "https://developer.vippsmobilepay.com/docs/SDKs/node-sdk",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vippsno/vipps-sdk",
-  "version": "0.9.15",
+  "version": "0.10.0",
   "homepage": "https://developer.vippsmobilepay.com/docs/SDKs/node-sdk",
   "repository": {
     "type": "git",

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -37,8 +37,7 @@ function makeRequest<TR>(
           try {
             const body = Buffer.concat(chunks).toString();
             if (!res.statusCode || res.statusCode < 200 || res.statusCode > 299) {
-              const error = new Error(`path=${req.path} ,statusCode=${res.statusCode}, contents=${body}`);
-              reject(error);
+              throw new Error(body);
             } else if (res.headers['content-type']?.includes('application/json')) {
               resolve(JSON.parse(body));
             } else if (res.headers['content-type']?.includes('text/plain')) {
@@ -46,7 +45,11 @@ function makeRequest<TR>(
             }
             resolve(null as TR);
           } catch (e) {
-            reject(e);
+            if (e instanceof Error) {
+              const message: Object = JSON.parse(e.message);
+              const result = { ...message, ok: false };
+              resolve(result as TR);
+            }
           }
         });
       })
@@ -63,9 +66,9 @@ function makeRequest<TR>(
 }
 
 export const get = <TR>(hostname: string, path: string, headers: OutgoingHttpHeaders): Promise<TR> =>
-  retry(() => makeRequest<TR>(hostname, 'GET', path, headers), { retries: 4 });
+  retry(() => makeRequest<TR>(hostname, 'GET', path, headers), { retries: 3 });
 
 export const post = <TI, TR>(hostname: string, path: string, headers: OutgoingHttpHeaders, requestData?: TI) =>
   retry(() => makeRequest<TR>(hostname, 'POST', path, headers, requestData), {
-    retries: 4,
+    retries: 3,
   });

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -46,7 +46,7 @@ function makeRequest<TR>(
             resolve(null as TR);
           } catch (e) {
             if (e instanceof Error) {
-              const message: Object = JSON.parse(e.message);
+              const message = JSON.parse(e.message);
               const result = { ...message, ok: false };
               resolve(result as TR);
             }

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -46,8 +46,7 @@ function makeRequest<TR>(
             resolve(null as TR);
           } catch (e) {
             if (e instanceof Error) {
-              const message = JSON.parse(e.message);
-              const result = { ...message, ok: false };
+              const result = { ok: false, error: JSON.parse(e.message) };
               resolve(result as TR);
             }
           }

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -46,7 +46,7 @@ function makeRequest<TR>(
             resolve(null as TR);
           } catch (e) {
             if (e instanceof Error) {
-              const result = { ok: false, error: JSON.parse(e.message) };
+              const result = { ok: false, message: JSON.parse(e.message) };
               resolve(result as TR);
             }
           }

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -46,7 +46,7 @@ function makeRequest<TR>(
             resolve(null as TR);
           } catch (e) {
             if (e instanceof Error) {
-              const result = { ok: false, message: JSON.parse(e.message) };
+              const result = { ok: false, error: JSON.parse(e.message) };
               resolve(result as TR);
             }
           }


### PR DESCRIPTION
The current error handling was not good, as it would crash in code and only return a string. Like so:
```
...
            throw new Error(body);
                  ^

Error: {"type":"https://httpstatuses.io/400","title":"Bad Request","status":400,"detail":"See extraDetails for further details","instance":"/v1/payments","traceId":"00-40478cc9d916924c1a5ea0503279467d-b7f9a51d9f15e882-00","extraDetails":[{"name":"createPaymentRequest","reason":"The createPaymentRequest field is required."},{"name":"amount.currency","reason":"Error converting value \"NOKK\" to type 'ePayment.V1.Auto.Models.Currency'. Path 'amount.currency', line 1, position 28."}]}
    at IncomingMessage.<anonymous> (file:///Users/tomas.zijdemans/Code/node-sdk/lib/index.mjs:107:19)
    at IncomingMessage.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
  ```
    
   This PR makes it slightly better, it will now fail like this:
   
   ```
   {
  type: 'https://httpstatuses.io/400',
  title: 'Bad Request',
  status: 400,
  detail: 'See extraDetails for further details',
  instance: '/v1/payments',
  traceId: '00-b3c4cc96d42e2e960ba6a7cf36e034e9-efe9e4c85abaaade-00',
  extraDetails: [
    {
      name: 'createPaymentRequest',
      reason: 'The createPaymentRequest field is required.'
    },
    {
      name: 'amount.currency',
      reason: `Error converting value "NOKK" to type 'ePayment.V1.Auto.Models.Currency'. Path 'amount.currency', line 1, position 28.`
    }
  ],
  ok: false
}
```
Now the user can check for ok being false. A better solution would be to type out the Error responses that are possible, and also have a ok: true for successful responses, so this is just slightly better.
   